### PR TITLE
 [Chris] Changed the 'for' method to stringify the keys instead of ca…

### DIFF
--- a/lib/poisol/stub/stub_builder_instance.rb
+++ b/lib/poisol/stub/stub_builder_instance.rb
@@ -57,7 +57,7 @@ module Poisol
     end
 
     def  for input_hash
-      @request.query.deep_merge! input_hash.camelize_keys
+      @request.query.deep_merge! input_hash.stringify_keys
       self
     end
 

--- a/spec/data/main/query/book.yml
+++ b/spec/data/main/query/book.yml
@@ -2,8 +2,8 @@ request:
   url: book
   method: get
   query:
-    author: "bharathi"
-    name: "doni"
+    author_id: "bharathi"
+    author_name: "doni"
 response:
   body:  '{
     "title": "independance",

--- a/spec/functional/query/query_explicit_spec.rb
+++ b/spec/functional/query/query_explicit_spec.rb
@@ -7,14 +7,14 @@ describe Poisol::Stub, "#query_explicit" do
   end
 
   it "full dymamic" do
-    Book.new.for_author('asd').for_name('don').build()
-    response = RestClient.get "http://localhost:3030/book",{:params => {:author=>'asd',:name=>'don'}}
+    Book.new.for_author_id('1').for_author_name('don').build()
+    response = RestClient.get "http://localhost:3030/book",{:params => {:author_id=>'1',:author_name=>'don'}}
     expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
   end
 
   it "full dymamic hash params" do
-    Book.new.for(:author => 'asd',:name =>'don').build
-    response = RestClient.get "http://localhost:3030/book",{:params => {:author=>'asd',:name=>'don'}}
+    Book.new.for(:author_id => '1',:author_name =>'don').build
+    response = RestClient.get "http://localhost:3030/book",{:params => {:author_id=>'1',:author_name=>'don'}}
     expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
   end
 

--- a/spec/functional/query/query_implicit_spec.rb
+++ b/spec/functional/query/query_implicit_spec.rb
@@ -1,20 +1,20 @@
 describe Poisol::Stub, "#implicit query params" do
 
   it "dynamic response" do
-    Book.new.for_author("bha").has_category({"age_group"=>"11", "publisher"=>{"name"=>"oxford"}}).build()
-    response = RestClient.get "http://localhost:3030/book",{:params => {:author=>'bha',:name=>"doni"}}
+    Book.new.for_author_id("1").has_category({"age_group"=>"11", "publisher"=>{"name"=>"oxford"}}).build()
+    response = RestClient.get "http://localhost:3030/book",{:params => {:author_id=>'1',:author_name=>"doni"}}
     expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"11", "genre"=>"action", "publisher"=>{"name"=>"oxford", "place"=>"erode"}}}.to_json)
   end
 
   it "default request and response" do
     Book.new.build()
-    response = RestClient.get "http://localhost:3030/book",{:params => {:author=>'bharathi',:name=>"doni"}}
+    response = RestClient.get "http://localhost:3030/book",{:params => {:author_id=>'bharathi',:author_name=>"doni"}}
     expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
   end
 
   it "hash params for query" do
-    Book.new.for(:author=>"val").build()
-    response = RestClient.get "http://localhost:3030/book",{:params => {:author=>'val',:name=>"doni"}}
+    Book.new.for(:author_id=>"1").build()
+    response = RestClient.get "http://localhost:3030/book",{:params => {:author_id=>'1',:author_name=>"doni"}}
     expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
   end
 


### PR DESCRIPTION
Issue: 
Given the book.yml contains
  ......
  query:
    author_id: "bharathi"
    author_name: "doni"
  ......
When using 'for' with query params having multi-words like, 
    Book.new.for(:author_id => '1')
Then the @request object gets created as,
    ACTUAL: @query="Query:authorId=1&author_id=bharathi"
    EXPECTED: @query="Query:author_id=1"



