### PR TITLE
Add support for custom query parameters

### DIFF
--- a/lib/poisol/stub/request/query_builder.rb
+++ b/lib/poisol/stub/request/query_builder.rb
@@ -16,7 +16,7 @@ module Poisol
       end
 
       define_method('without') do |key|
-        @request.query.delete key
+        @request.query.delete key.to_s
         self
       end
     end

--- a/lib/poisol/stub/request/query_builder.rb
+++ b/lib/poisol/stub/request/query_builder.rb
@@ -1,13 +1,23 @@
-module Poisol 
+module Poisol
   module QueryBuilder
     def generate_query_methods
-      query = @stub_config.request.query 
+      query = @stub_config.request.query
       query.each do |field|
         field_name = field[0]
         define_method("for_#{field[0].underscore}") do |*value|
           @request.query[field_name] = value[0]
           self
         end
+      end
+
+      define_method('for_custom') do |params|
+        @request.query.merge!(params)
+        self
+      end
+
+      define_method('without') do |key|
+        @request.query.delete key
+        self
       end
     end
   end

--- a/spec/functional/query/query_explicit_spec.rb
+++ b/spec/functional/query/query_explicit_spec.rb
@@ -25,7 +25,7 @@ describe Poisol::Stub, "#query_explicit" do
   end
 
   it "removes default query params" do
-    Book.new.without('author').build()
+    Book.new.without(:author).build()
     response = RestClient.get "http://localhost:3030/book",{:params => {:name=> 'doni'}}
     expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
   end

--- a/spec/functional/query/query_explicit_spec.rb
+++ b/spec/functional/query/query_explicit_spec.rb
@@ -18,4 +18,15 @@ describe Poisol::Stub, "#query_explicit" do
     expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
   end
 
+  it "add custom query params" do
+    Book.new.for_custom(color: 'red').for_author('bha').for_name('don').build()
+    response = RestClient.get "http://localhost:3030/book",{:params => {:author => 'bha',:name=> 'don',:color=>'red'}}
+    expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
+  end
+
+  it "removes default query params" do
+    Book.new.without('author').build()
+    response = RestClient.get "http://localhost:3030/book",{:params => {:name=> 'doni'}}
+    expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
+  end
 end

--- a/spec/functional/query/query_implicit_spec.rb
+++ b/spec/functional/query/query_implicit_spec.rb
@@ -17,7 +17,4 @@ describe Poisol::Stub, "#implicit query params" do
     response = RestClient.get "http://localhost:3030/book",{:params => {:author=>'val',:name=>"doni"}}
     expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
   end
-
-
 end
-


### PR DESCRIPTION
Given the following yml stub
```yml
request:
  url: book
  method: get
  query:
    author: "asd"
    name: "don"
response:
  body:  '{
    "title": "independance",
    "category": {
      "age_group": "10",
      "genre": "action",
      "publisher": {
        "name": "summa",
        "place":"erode"
      }
    }
  }'
```

## Support for custom query parameters
```ruby
Book.new.for_custom({color: 'red'}).build
```
Will stub ```http://localhost:3030/book?author=asd&name=don&color=red```

## Support removing default query paramters
```ruby
Book.new.without(:author).build
```
Will remove the default ```author``` query parameter and stub ```http://localhost:3030/book?name=don```