### PR TITLE
Ignored comparision of base url as some client libraries doesn't pass them

### DIFF
--- a/lib/poisol/domain.rb
+++ b/lib/poisol/domain.rb
@@ -10,7 +10,7 @@ module Poisol
         sub_domain  = base_hash["sub_domain"]
         path = "/#{sub_domain}" if sub_domain.present?
       end
-      @full_url = "#{Server.base_url}#{ path.present? ? path: ''}"
+      @full_url = "#{ path.present? ? path: ''}"
     end
 
   end

--- a/lib/poisol/server.rb
+++ b/lib/poisol/server.rb
@@ -8,7 +8,7 @@ module Poisol
       stub_response = Poisol::ResponseMapper.map(req)
       res.status = stub_response.status
       res.body = stub_response.body.to_json
-      res.content_type = 'application/json'
+      res.header.merge! stub_response.header
     end
     alias do_DELETE do_GET
     alias do_POST do_GET
@@ -49,7 +49,7 @@ module Poisol
     def access_log
       log_file = File.open 'log/poisol_webrick.log', 'a+'
       [
-        [log_file, WEBrick::AccessLog::COMBINED_LOG_FORMAT],
+        [log_file, "#{WEBrick::AccessLog::COMBINED_LOG_FORMAT} %T"],
       ]
     end
 

--- a/lib/poisol/stub/response/response_body_builder.rb
+++ b/lib/poisol/stub/response/response_body_builder.rb
@@ -3,7 +3,7 @@ module Poisol
 
     def prepare_response_body
       return if @stub_config.response.body.blank?
-      if  @stub_config.response.is_column_array or @stub_config.response.is_row_array 
+      if  @stub_config.response.is_column_array or @stub_config.response.is_row_array
         make_methods_to_alter_response_array
       else
         make_methods_to_alter_response_object 

--- a/lib/poisol/stub/stub_builder_instance.rb
+++ b/lib/poisol/stub/stub_builder_instance.rb
@@ -16,13 +16,17 @@ module Poisol
 
     def init_response
       @response = Response.new
-      if  stub_config.response.is_column_array or stub_config.response.is_row_array 
-        @response.body = [stub_config.response.body.deep_dup] 
+      if stub_config.response.is_column_array or stub_config.response.is_row_array
+        @response.body = [stub_config.response.body.deep_dup]
       else
         @response.body = stub_config.response.body.deep_dup
       end
       @response.status = 200
+
       @response.header = {'Content-Type' => 'application/json'}
+      if (stub_config.response.header)
+        @response.header.merge! stub_config.response.header
+      end
     end
 
     def set_dumb_response response_file
@@ -31,10 +35,10 @@ module Poisol
       self
     end
 
-    def get_assignment_value actual_field_value,input_value
-      if  actual_field_value.class.to_s == "Hash" 
+    def get_assignment_value actual_field_value, input_value
+      if actual_field_value.class.to_s == "Hash"
         input_value = {} if input_value.blank?
-        actual_field_value.deep_merge(input_value.stringify_keys) 
+        actual_field_value.deep_merge(input_value.stringify_keys)
       else
         input_value
       end
@@ -56,18 +60,18 @@ module Poisol
       self
     end
 
-    def  for input_hash
+    def for input_hash
       @request.query.deep_merge! input_hash.stringify_keys
       self
     end
 
-    def  status input
+    def status input
       @response.status = input
       self
     end
 
     def remove_array_field_calls
-      method_of_array_fileds_of_array = self.methods.select{|method_name|method_name.to_s.start_with?"with_"}
+      method_of_array_fileds_of_array = self.methods.select { |method_name| method_name.to_s.start_with? "with_" }
       @called_methods = @called_methods - method_of_array_fileds_of_array
     end
   end

--- a/lib/poisol/stub_config/stub_config.rb
+++ b/lib/poisol/stub_config/stub_config.rb
@@ -8,6 +8,6 @@ module Poisol
   end
 
   class ResponseConfig
-    attr_accessor :body,:is_column_array,:is_row_array
+    attr_accessor :body,:is_column_array,:is_row_array, :header
   end
 end

--- a/lib/poisol/stub_config/stub_config_builder.rb
+++ b/lib/poisol/stub_config/stub_config_builder.rb
@@ -77,6 +77,14 @@ module Poisol
     def build_response
       @stub_config.is_inline ? load_inline_response_body  : load_exploaded_response_body
       load_resonse_array_type
+      load_header
+    end
+
+    def load_header
+      return if @raw_config_hash["response"].blank?
+      header = @raw_config_hash["response"]["header"]
+      return if header.blank?
+      @stub_config.response.header = header
     end
 
     def load_resonse_array_type

--- a/lib/poisol/stub_mapper/response_mapper.rb
+++ b/lib/poisol/stub_mapper/response_mapper.rb
@@ -5,15 +5,14 @@ module Poisol
     def map webrick_request
       stub_request = get_stub_request webrick_request
       PoisolLog.info stub_request.to_s
-      stub_response = get_stub_response stub_request
+      get_stub_response stub_request
     end
 
     def get_stub_request webrick_request
       stub_request = Request.new 
       stub_request.type = webrick_request.request_method.downcase
-      uri = webrick_request.request_uri
-      stub_request.url = uri.query.blank? ? uri.to_s : uri.to_s.sub(uri.query,"").sub("?","")
-      stub_request.query = webrick_request.query_string 
+      stub_request.url = webrick_request.request_uri.path
+      stub_request.query = webrick_request.query_string
       stub_request.body = webrick_request.body
       stub_request
     end
@@ -26,7 +25,7 @@ module Poisol
         raise "No match found for request: #{stub_request.to_s} "
       end
       PoisolLog.info JSON.pretty_generate(stub.response.body)
-      return stub.response if stub.present?
+      stub.response if stub.present?
     end
 
     def log_error request

--- a/spec/data/main/query/book_explicit.yml
+++ b/spec/data/main/query/book_explicit.yml
@@ -6,6 +6,8 @@ request:
     author: "bharathi"
     name: "doni"
 response:
+  header:
+    Content-Language: "en"
   body:  '{
     "title": "independance",
     "category": {

--- a/spec/functional/query/query_explicit_spec.rb
+++ b/spec/functional/query/query_explicit_spec.rb
@@ -18,4 +18,10 @@ describe Poisol::Stub, "#query_explicit" do
     expect(response.body).to eq({"title"=>"independance", "category"=>{"age_group"=>"10", "genre"=>"action", "publisher"=>{"name"=>"summa", "place"=>"erode"}}}.to_json)
   end
 
+  it "should be able to configure headers" do
+    BookExplicit.new.for_author('bha').build()
+    response = RestClient.get "http://localhost:3030/book_explicit",{:params => {:author=>'bha'}}
+    expect(response.headers[:content_language]).to eq("en")
+  end
+
 end


### PR DESCRIPTION
If there is a request coming in to the server then the base url is already verified. So we don't need to add it to the url while comparing.